### PR TITLE
WindowHeader 컴포넌트 기능 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
   const appIds = useRecoilValue(appIdsAtom);
 
   return (
-    <main className="relative w-full h-full flex flex-col justify-center items-center">
+    <main className="main relative w-full h-full flex flex-col justify-center items-center">
       {appIds.map((id) => (
         <AppWindow key={id} id={id} />
       ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import { appsState } from "@/stores/app";
+import { appAtomFamily, appIdsAtom } from "@/stores/app";
+import { AppData } from "@/types/app";
 import { useRecoilValue } from "recoil";
 
 export default function Home() {
-  const apps = useRecoilValue(appsState);
+  const appIds = useRecoilValue(appIdsAtom);
 
   return (
     <main className="relative w-full h-full flex flex-col justify-center items-center">
-      {apps.map(({ active, content }) => (active ? content : null))}
+      {appIds.map((id) => (
+        <AppWindow key={id} id={id} />
+      ))}
     </main>
   );
 }
+
+const AppWindow = ({ id }: Pick<AppData, "id">) => {
+  const app = useRecoilValue(appAtomFamily(id));
+  return app.active ? app.content : null;
+};

--- a/src/components/App/Chrome.tsx
+++ b/src/components/App/Chrome.tsx
@@ -1,0 +1,15 @@
+import { AppData } from "@/types/app";
+import Window from "../Window/Window";
+
+const ID: AppData["id"] = "chrome";
+
+const Chrome = () => {
+  return (
+    <Window>
+      <Window.Header id={ID} />
+      <Window.Body>Body...</Window.Body>
+    </Window>
+  );
+};
+
+export default Chrome;

--- a/src/components/Dock/Dock.tsx
+++ b/src/components/Dock/Dock.tsx
@@ -10,7 +10,7 @@ const Dock = () => {
   const appIds = useRecoilValue(appIdsAtom);
 
   return (
-    <footer className="fixed inset-x-0 bottom-0 w-full z-50">
+    <footer className="inset-x-0 bottom-0 w-full z-20">
       <nav className="flex mx-auto w-max justify-center rounded-2xl bg-white/30 backdrop-blur-sm shadow-2xl">
         <ul
           className={`flex justify-center items-end h-[76px] p-0.5`}

--- a/src/components/Dock/Dock.tsx
+++ b/src/components/Dock/Dock.tsx
@@ -3,21 +3,11 @@
 import { useRecoilState, useRecoilValue } from "recoil";
 import DockItem from "./DockItem";
 import { useState } from "react";
-import { appsState } from "@/stores/app";
-import { AppData } from "@/types/app";
+import { appIdsAtom } from "@/stores/app";
 
 const Dock = () => {
   const [mouseX, setMouseX] = useState<number | null>(null);
-  const [apps, setApps] = useRecoilState(appsState);
-
-  const handleClickDockItem = (id: AppData["id"]) => {
-    setApps(
-      apps.map((app) => {
-        if (app.id === id) return { ...app, active: !app.active };
-        return app;
-      })
-    );
-  };
+  const appIds = useRecoilValue(appIdsAtom);
 
   return (
     <footer className="fixed inset-x-0 bottom-0 w-full z-50">
@@ -27,13 +17,8 @@ const Dock = () => {
           onMouseMove={(event) => setMouseX(event.clientX)}
           onMouseLeave={() => setMouseX(null)}
         >
-          {apps.map((app) => (
-            <DockItem
-              key={app.id}
-              {...app}
-              mouseX={mouseX}
-              onClick={() => handleClickDockItem(app.id)}
-            />
+          {appIds.map((id) => (
+            <DockItem key={id} id={id} mouseX={mouseX} />
           ))}
         </ul>
       </nav>

--- a/src/components/Dock/DockItem.tsx
+++ b/src/components/Dock/DockItem.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { appAtomFamily } from "@/stores/app";
 import { AppData } from "@/types/app";
 import { motion, useMotionValue, useSpring, useTransform } from "framer-motion";
 import Image from "next/image";
-import { ComponentProps, RefObject, useRef } from "react";
+import { RefObject, useRef } from "react";
+import { useRecoilState } from "recoil";
 
 const DEFAULT_SIZE = 64;
 const MAGNIFICATION_MAX = 1.8;
@@ -49,23 +51,23 @@ interface DockItemProps {
   mouseX: number | null;
 }
 
-const DockItem = ({
-  name,
-  iconUrl,
-  active,
-  mouseX,
-  onClick,
-}: AppData & DockItemProps & Pick<ComponentProps<"li">, "onClick">) => {
+const DockItem = ({ id, mouseX }: Pick<AppData, "id"> & DockItemProps) => {
   const imageWrapRef = useRef<HTMLDivElement>(null);
   const calculateSize = useCalculateSize(imageWrapRef, mouseX);
+
+  const [app, setApp] = useRecoilState(appAtomFamily(id));
+
+  const handleClickDockItem = () => {
+    setApp({ ...app, active: !app.active });
+  };
 
   return (
     <li
       className="group p-0.5 pb-1.5 flex flex-col items-center"
-      onClick={onClick}
+      onClick={handleClickDockItem}
     >
       <div className="group-hover:block hidden absolute w-max mt-[-2.5rem] px-4 py-0.5 text-sm bg-lightgrey/90 rounded shadow-2xl after:content-[''] after:border-t-[0.5rem] after:border-x-[0.5rem] after:border-transparent after:border-t-lightgrey/90 after:absolute after:bottom-[-0.5rem] after:left-[50%] after:translate-x-[-50%] after:h-0">
-        {name}
+        {app.name}
       </div>
       <motion.div
         ref={imageWrapRef}
@@ -76,8 +78,8 @@ const DockItem = ({
         }}
       >
         <Image
-          src={iconUrl}
-          alt={name}
+          src={app.iconUrl}
+          alt={app.name}
           fill
           sizes="128px"
           quality={75}
@@ -85,7 +87,7 @@ const DockItem = ({
         />
       </motion.div>
 
-      {active && (
+      {app.active && (
         <div className="absolute bottom-[0.15rem] rounded-full w-1 h-1 bg-slate-700/90" />
       )}
     </li>

--- a/src/components/Window/Window.tsx
+++ b/src/components/Window/Window.tsx
@@ -52,18 +52,18 @@ const Window = ({ children }: PropsWithChildren) => {
         })
       }
       onDragStop={(_event, { x, y }) => setSize({ ...size, x, y })}
+      style={{
+        display: "flex",
+      }}
       dragHandleClassName="header"
-      className="relative rounded-lg bg-lightgrey/95"
+      className="relative rounded-lg flex-col"
     >
       {children}
     </Rnd>
   );
 };
 
-const WindowHeader = ({
-  id,
-  children,
-}: Pick<AppData, "id"> & PropsWithChildren) => {
+const Header = ({ id }: Pick<AppData, "id"> & PropsWithChildren) => {
   const [app, setApp] = useRecoilState(appAtomFamily(id));
 
   const handleClickRedButton = () => {
@@ -73,8 +73,8 @@ const WindowHeader = ({
   const handleClickGreenButton = () => {};
 
   return (
-    <div className="header flex px-4 py-1">
-      <div className="flex items-center gap-1.5">
+    <div className="header flex items-center justify-center px-4 py-1 bg-lightgrey/95 rounded-t-lg">
+      <div className="absolute left-0 flex items-center gap-1.5 px-4 py-1">
         <button
           className="w-3 h-3 bg-red-400 border border-red-500 rounded-full"
           onClick={handleClickRedButton}
@@ -85,9 +85,20 @@ const WindowHeader = ({
           onClick={handleClickGreenButton}
         />
       </div>
+      <h1 className="self-center">{app.name}</h1>
+    </div>
+  );
+};
+
+const Body = ({ children }: PropsWithChildren) => {
+  return (
+    <div className="w-full h-full px-2 py-0.5 bg-white/95 rounded-b-lg">
       {children}
     </div>
   );
 };
+
+Window.Header = Header;
+Window.Body = Body;
 
 export default Window;

--- a/src/components/Window/Window.tsx
+++ b/src/components/Window/Window.tsx
@@ -31,7 +31,7 @@ const Window = ({ children }: PropsWithChildren) => {
 
   return (
     <Rnd
-      bounds="parent"
+      bounds=".main"
       handle=".cursor"
       minWidth={600}
       minHeight={400}
@@ -68,6 +68,8 @@ const Window = ({ children }: PropsWithChildren) => {
       enableResizing={!isMaxSize}
       style={{
         display: "flex",
+        transitionProperty: "transform, width, height",
+        transitionDuration: "0.3s, 0.1s, 0.1s",
       }}
       dragHandleClassName="header"
       className="rounded-lg flex-col z-60"

--- a/src/components/Window/Window.tsx
+++ b/src/components/Window/Window.tsx
@@ -1,13 +1,17 @@
 "use client";
 
+import { appAtomFamily } from "@/stores/app";
+import { AppData } from "@/types/app";
 import { PropsWithChildren, useState } from "react";
 import { Rnd } from "react-rnd";
+import { useRecoilState } from "recoil";
 
 type WindowState = {
   width: number;
   height: number;
   x: number;
   y: number;
+  isMax: boolean;
 };
 
 const Window = ({ children }: PropsWithChildren) => {
@@ -16,10 +20,12 @@ const Window = ({ children }: PropsWithChildren) => {
     height: 600,
     x: 200,
     y: 100,
+    isMax: false,
   });
 
   return (
     <Rnd
+      bounds="parent"
       handle=".cursor"
       minWidth={600}
       minHeight={400}
@@ -49,16 +55,39 @@ const Window = ({ children }: PropsWithChildren) => {
       dragHandleClassName="header"
       className="relative rounded-lg bg-lightgrey/95"
     >
-      <Header />
       {children}
     </Rnd>
   );
 };
 
-const Header = ({ children }: PropsWithChildren) => {
-  return <div className="header px-2 py-1">{children}</div>;
-};
+const WindowHeader = ({
+  id,
+  children,
+}: Pick<AppData, "id"> & PropsWithChildren) => {
+  const [app, setApp] = useRecoilState(appAtomFamily(id));
 
-Window.Header = Header;
+  const handleClickRedButton = () => {
+    setApp({ ...app, active: !app.active });
+  };
+
+  const handleClickGreenButton = () => {};
+
+  return (
+    <div className="header flex px-4 py-1">
+      <div className="flex items-center gap-1.5">
+        <button
+          className="w-3 h-3 bg-red-400 border border-red-500 rounded-full"
+          onClick={handleClickRedButton}
+        />
+        <button className="w-3 h-3 bg-yellow-400 border border-yellow-500 rounded-full" />
+        <button
+          className="w-3 h-3 bg-green-400 border border-green-500 rounded-full"
+          onClick={handleClickGreenButton}
+        />
+      </div>
+      {children}
+    </div>
+  );
+};
 
 export default Window;

--- a/src/stores/app.tsx
+++ b/src/stores/app.tsx
@@ -1,31 +1,43 @@
 import Window from "@/components/Window/Window";
 import { AppData } from "@/types/app";
-import { atom } from "recoil";
+import { atom, atomFamily } from "recoil";
 
-export const appsState = atom<AppData[]>({
-  key: "apps",
-  default: [
-    {
-      id: "finder",
-      name: "Finder",
-      iconUrl: "/icons/app/finder.png",
-      active: false,
-      content: (
-        <Window>
-          <Window.Header>Finder</Window.Header>
-        </Window>
-      ),
-    },
-    {
-      id: "chrome",
-      name: "Google Chrome",
-      iconUrl: "/icons/app/chrome.png",
-      active: false,
-      content: (
-        <Window>
-          <Window.Header>Chrome</Window.Header>
-        </Window>
-      ),
-    },
-  ],
+const getName = (appId: AppData["id"]) => {
+  switch (appId) {
+    case "finder":
+      return "Finder";
+    case "chrome":
+      return "Google Chrome";
+    default:
+      console.error(`${appId}는 올바르지 않은 appId 에요.`);
+      return "";
+  }
+};
+
+const getContent = (appId: AppData["id"]) => {
+  switch (appId) {
+    case "finder":
+      return <Window />;
+    case "chrome":
+      return <Window />;
+    default:
+      console.error(`${appId}는 올바르지 않은 appId 에요.`);
+      return <></>;
+  }
+};
+
+export const appAtomFamily = atomFamily<AppData, AppData["id"]>({
+  key: "appAtomFamily",
+  default: (id) => ({
+    id,
+    name: getName(id),
+    iconUrl: `/icons/app/${id}.png`,
+    active: false,
+    content: getContent(id),
+  }),
+});
+
+export const appIdsAtom = atom<AppData["id"][]>({
+  key: "appIdsAtom",
+  default: ["finder", "chrome"],
 });

--- a/src/stores/app.tsx
+++ b/src/stores/app.tsx
@@ -1,11 +1,9 @@
-import Window from "@/components/Window/Window";
+import Chrome from "@/components/App/Chrome";
 import { AppData } from "@/types/app";
 import { atom, atomFamily } from "recoil";
 
 const getName = (appId: AppData["id"]) => {
   switch (appId) {
-    case "finder":
-      return "Finder";
     case "chrome":
       return "Google Chrome";
     default:
@@ -16,10 +14,8 @@ const getName = (appId: AppData["id"]) => {
 
 const getContent = (appId: AppData["id"]) => {
   switch (appId) {
-    case "finder":
-      return <Window />;
     case "chrome":
-      return <Window />;
+      return <Chrome />;
     default:
       console.error(`${appId}는 올바르지 않은 appId 에요.`);
       return <></>;
@@ -34,10 +30,11 @@ export const appAtomFamily = atomFamily<AppData, AppData["id"]>({
     iconUrl: `/icons/app/${id}.png`,
     active: false,
     content: getContent(id),
+    isMaxSize: false,
   }),
 });
 
 export const appIdsAtom = atom<AppData["id"][]>({
   key: "appIdsAtom",
-  default: ["finder", "chrome"],
+  default: ["chrome"],
 });

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -1,7 +1,8 @@
 export interface AppData {
-  id: "finder" | "chrome";
+  id: "chrome";
   name: string;
   iconUrl: string;
   content: JSX.Element;
   active: boolean;
+  isMaxSize: boolean;
 }


### PR DESCRIPTION
#8 

* atomFamily로 앱 별로 atom을 관리할 수 있도록 수정했어요.
* 빨간색 버튼을 클릭하면 윈도우가 닫히도록 구현했어요.
* 초록색 버튼을 클릭하거나, 윈도우 헤더를 더블 클릭하면 윈도우가 최대 크기로 확대되도록 구현했어요.
* 윈도우 컴포넌트의 리사이징 트랜지션을 추가했어요.