### PR TITLE
Window 컴포넌트 focus 이벤트 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,11 +29,7 @@ export default function RootLayout({
               placeholder="blur"
             />
           </div>
-          <div className="relative w-full h-full flex flex-col">
-            <MenuBar />
-            {children}
-            <Dock />
-          </div>
+          {children}
         </RecoilRootWrapper>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,24 +1,30 @@
 "use client";
 
-import { appAtomFamily } from "@/stores/app";
+import Dock from "@/components/Dock/Dock";
+import MenuBar from "@/components/MenuBar/MenuBar";
+import { appsAtom } from "@/stores/app";
 import { AppData } from "@/types/app";
-import { appIds } from "@/utils/constants/app";
 import { useRecoilValue } from "recoil";
 
 export default function Home() {
+  const apps = useRecoilValue(appsAtom);
+
   return (
-    <main
-      id="main"
-      className="relative w-full h-full flex flex-col justify-center items-center"
-    >
-      {appIds.map((id) => (
-        <AppWindow key={id} id={id} />
-      ))}
-    </main>
+    <div className="relative w-full h-full flex flex-col">
+      <MenuBar />
+      <main
+        id="main"
+        className="relative w-full h-full flex flex-col justify-center items-center"
+      >
+        {apps.map((app) => (
+          <AppWindow key={app.id} {...app} />
+        ))}
+      </main>
+      <Dock />
+    </div>
   );
 }
 
-const AppWindow = ({ id }: Pick<AppData, "id">) => {
-  const app = useRecoilValue(appAtomFamily(id));
-  return app.active ? app.content : null;
+const AppWindow = ({ active, content }: AppData) => {
+  return active ? content : null;
 };

--- a/src/components/App/Blog.tsx
+++ b/src/components/App/Blog.tsx
@@ -7,6 +7,8 @@ import RightArrowIcon from "@public/icons/chrome/right-arrow.svg?react";
 import RefreshIcon from "@public/icons/chrome/refresh.svg?react";
 import HomeIcon from "@public/icons/chrome/home.svg?react";
 import { useRouter } from "next/navigation";
+import { useRecoilCallback } from "recoil";
+import { appsAtom } from "@/stores/app";
 
 const ID: AppData["id"] = "blog";
 

--- a/src/components/App/PhotoBooth.tsx
+++ b/src/components/App/PhotoBooth.tsx
@@ -16,14 +16,12 @@ const PhotoBooth = () => {
   }, []);
 
   return (
-    <Window id={ID}>
+    <Window id={ID} lockSize>
       <Window.Body>
-        <div className="rounded-b-lg">
-          <video
-            ref={videoRef}
-            className="w-full h-full rotate-y-180 rounded-b-lg"
-          />
-        </div>
+        <video
+          ref={videoRef}
+          className="w-full rotate-y-180 rounded-b-lg object-contain"
+        />
       </Window.Body>
     </Window>
   );

--- a/src/components/Dock/Dock.tsx
+++ b/src/components/Dock/Dock.tsx
@@ -2,9 +2,21 @@
 
 import DockItem from "./DockItem";
 import { useState } from "react";
-import { appIds } from "@/utils/constants/app";
+import { appsAtom } from "@/stores/app";
+import { useRecoilState } from "recoil";
 
 const Dock = () => {
+  const [apps, setApps] = useRecoilState(appsAtom);
+
+  const handleClickDockItem = (id: string) => {
+    const copiedApps = [...apps].map((app) => ({
+      ...app,
+      active: app.id === id ? !app.active : app.active,
+      focus: app.id === id ? true : false,
+    }));
+    setApps(copiedApps);
+  };
+
   const [mouseX, setMouseX] = useState<number | null>(null);
 
   return (
@@ -15,8 +27,13 @@ const Dock = () => {
           onMouseMove={(event) => setMouseX(event.clientX)}
           onMouseLeave={() => setMouseX(null)}
         >
-          {appIds.map((id) => (
-            <DockItem key={id} id={id} mouseX={mouseX} />
+          {apps.map((app) => (
+            <DockItem
+              key={app.id}
+              mouseX={mouseX}
+              onClick={() => handleClickDockItem(app.id)}
+              {...app}
+            />
           ))}
         </ul>
       </nav>

--- a/src/components/Dock/DockItem.tsx
+++ b/src/components/Dock/DockItem.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { appAtomFamily } from "@/stores/app";
 import { AppData } from "@/types/app";
 import { motion, useMotionValue, useSpring, useTransform } from "framer-motion";
 import Image from "next/image";
 import { RefObject, useRef } from "react";
-import { useRecoilState } from "recoil";
 
 const DEFAULT_SIZE = 64;
 const MAGNIFICATION_MAX = 1.8;
@@ -47,27 +45,29 @@ const useCalculateSize = (
   return calculateSize;
 };
 
-interface DockItemProps {
+interface DockItemProps
+  extends Pick<AppData, "id" | "name" | "iconUrl" | "active"> {
   mouseX: number | null;
+  onClick: () => void;
 }
 
-const DockItem = ({ id, mouseX }: Pick<AppData, "id"> & DockItemProps) => {
+const DockItem = ({
+  name,
+  iconUrl,
+  active,
+  onClick,
+  mouseX,
+}: DockItemProps) => {
   const imageWrapRef = useRef<HTMLDivElement>(null);
   const calculateSize = useCalculateSize(imageWrapRef, mouseX);
-
-  const [app, setApp] = useRecoilState(appAtomFamily(id));
-
-  const handleClickDockItem = () => {
-    setApp({ ...app, active: !app.active });
-  };
 
   return (
     <li
       className="group p-0.5 pb-1.5 flex flex-col items-center"
-      onClick={handleClickDockItem}
+      onClick={onClick}
     >
       <div className="group-hover:block hidden absolute w-max mt-[-2.5rem] px-4 py-0.5 text-sm bg-lightgrey/90 rounded shadow-2xl after:content-[''] after:border-t-[0.5rem] after:border-x-[0.5rem] after:border-transparent after:border-t-lightgrey/90 after:absolute after:bottom-[-0.5rem] after:left-[50%] after:translate-x-[-50%] after:h-0">
-        {app.name}
+        {name}
       </div>
       <motion.div
         ref={imageWrapRef}
@@ -78,8 +78,8 @@ const DockItem = ({ id, mouseX }: Pick<AppData, "id"> & DockItemProps) => {
         }}
       >
         <Image
-          src={app.iconUrl}
-          alt={app.name}
+          src={iconUrl}
+          alt={name}
           fill
           sizes="128px"
           quality={75}
@@ -87,7 +87,7 @@ const DockItem = ({ id, mouseX }: Pick<AppData, "id"> & DockItemProps) => {
         />
       </motion.div>
 
-      {app.active && (
+      {active && (
         <div className="absolute bottom-[0.15rem] rounded-full w-1 h-1 bg-slate-700/90" />
       )}
     </li>

--- a/src/components/Window/Window.tsx
+++ b/src/components/Window/Window.tsx
@@ -1,12 +1,26 @@
 "use client";
 
-import { appAtomFamily } from "@/stores/app";
+import { appState, appsAtom } from "@/stores/app";
 import { AppData } from "@/types/app";
 import { PropsWithChildren } from "react";
-import { useRecoilState } from "recoil";
+import {
+  useRecoilCallback,
+  useRecoilState,
+  useRecoilValue,
+  useSetRecoilState,
+} from "recoil";
 
-const Window = ({ id, children }: Pick<AppData, "id"> & PropsWithChildren) => {
-  const [app, setApp] = useRecoilState(appAtomFamily(id));
+interface WindowProps {
+  id: AppData["id"];
+  lockSize?: boolean;
+}
+
+const Window = ({
+  id,
+  lockSize = false,
+  children,
+}: WindowProps & PropsWithChildren) => {
+  const [app, setApp] = useRecoilState(appState(id));
 
   const { isMaxSize, size, position } = app;
 
@@ -147,51 +161,75 @@ const Window = ({ id, children }: Pick<AppData, "id"> & PropsWithChildren) => {
     window.addEventListener("mouseup", handleMouseUp);
   };
 
+  const zIndex = app.focus ? `z-[11]` : `z-10`;
+
+  const handleFocus = useRecoilCallback(
+    ({ set }) =>
+      () => {
+        set(appsAtom, (apps) => {
+          return apps.map((app) => ({
+            ...app,
+            focus: app.id === id ? true : false,
+          }));
+        });
+      },
+    []
+  );
+
   return (
     <div
-      className="window absolute flex rounded-lg flex-col z-10"
+      className={`window absolute flex rounded-lg flex-col ${zIndex}`}
       style={{ ...sizeStyle, ...positionStyle }}
+      onMouseDownCapture={handleFocus}
+      tabIndex={-1}
     >
-      <div
-        className="absolute -top-0.5 -left-0.5 w-2.5 h-2.5 cursor-nwse-resize z-30 select-none"
-        onMouseDown={(event) => handleMouseDown(event, "top-left")}
-      />
-      <div
-        className="absolute -top-1 w-full h-2 cursor-ns-resize z-20 select-none"
-        onMouseDown={(event) => handleMouseDown(event, "top")}
-      />
-      <div
-        className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 cursor-nesw-resize z-30 select-none"
-        onMouseDown={(event) => handleMouseDown(event, "top-right")}
-      />
-      <div
-        className="absolute -right-1 w-2 h-full cursor-ew-resize z-20 select-none"
-        onMouseDown={(event) => handleMouseDown(event, "right")}
-      />
-      <div
-        className="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 cursor-nwse-resize z-30 select-none"
-        onMouseDown={(event) => handleMouseDown(event, "bottom-right")}
-      />
-      <div
-        className="absolute -bottom-1 w-full h-2 cursor-ns-resize z-20 select-none"
-        onMouseDown={(event) => handleMouseDown(event, "bottom")}
-      />
-      <div
-        className="absolute -bottom-0.5 -left-0.5 w-2.5 h-2.5 cursor-nesw-resize z-30 select-none"
-        onMouseDown={(event) => handleMouseDown(event, "bottom-left")}
-      />
-      <div
-        className="absolute -left-1 w-2 h-full cursor-ew-resize z-20 select-none"
-        onMouseDown={(event) => handleMouseDown(event, "left")}
-      />
+      {!lockSize && (
+        <>
+          <div
+            className="absolute -top-0.5 -left-0.5 w-2.5 h-2.5 cursor-nwse-resize z-30 select-none"
+            onMouseDown={(event) => handleMouseDown(event, "top-left")}
+          />
+          <div
+            className="absolute -top-1 w-full h-2 cursor-ns-resize z-20 select-none"
+            onMouseDown={(event) => handleMouseDown(event, "top")}
+          />
+          <div
+            className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 cursor-nesw-resize z-30 select-none"
+            onMouseDown={(event) => handleMouseDown(event, "top-right")}
+          />
+          <div
+            className="absolute -right-1 w-2 h-full cursor-ew-resize z-20 select-none"
+            onMouseDown={(event) => handleMouseDown(event, "right")}
+          />
+          <div
+            className="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 cursor-nwse-resize z-30 select-none"
+            onMouseDown={(event) => handleMouseDown(event, "bottom-right")}
+          />
+          <div
+            className="absolute -bottom-1 w-full h-2 cursor-ns-resize z-20 select-none"
+            onMouseDown={(event) => handleMouseDown(event, "bottom")}
+          />
+          <div
+            className="absolute -bottom-0.5 -left-0.5 w-2.5 h-2.5 cursor-nesw-resize z-30 select-none"
+            onMouseDown={(event) => handleMouseDown(event, "bottom-left")}
+          />
+          <div
+            className="absolute -left-1 w-2 h-full cursor-ew-resize z-20 select-none"
+            onMouseDown={(event) => handleMouseDown(event, "left")}
+          />
+        </>
+      )}
       <Header id={id} />
+      {!app.focus && (
+        <div className={`absolute w-full h-full opacity-0 ${zIndex}`} />
+      )}
       {children}
     </div>
   );
 };
 
 const Header = ({ id }: Pick<AppData, "id"> & PropsWithChildren) => {
-  const [app, setApp] = useRecoilState(appAtomFamily(id));
+  const [app, setApp] = useRecoilState(appState(id));
 
   const handleClickRedButton = (event: React.MouseEvent<HTMLButtonElement>) => {
     setApp({ ...app, active: !app.active });

--- a/src/stores/app.tsx
+++ b/src/stores/app.tsx
@@ -1,48 +1,62 @@
 import Blog from "@/components/App/Blog";
 import PhotoBooth from "@/components/App/PhotoBooth";
 import { AppData } from "@/types/app";
-import { atom, atomFamily } from "recoil";
+import { atom, selectorFamily } from "recoil";
 
-const getName = (appId: AppData["id"]) => {
-  switch (appId) {
-    case "blog":
-      return "Blog.minjong";
-    case "photo-booth":
-      return "Photo Booth";
-    default:
-      console.error(`${appId}는 올바르지 않은 appId 에요.`);
-      return "";
-  }
-};
-
-const getContent = (appId: AppData["id"]) => {
-  switch (appId) {
-    case "blog":
-      return <Blog />;
-    case "photo-booth":
-      return <PhotoBooth />;
-    default:
-      console.error(`${appId}는 올바르지 않은 appId 에요.`);
-      return <></>;
-  }
-};
-
-export const appAtomFamily = atomFamily<AppData, AppData["id"]>({
-  key: "appAtomFamily",
-  default: (id) => ({
-    id,
-    name: getName(id),
-    iconUrl: `/icons/app/${id}.png`,
-    active: false,
-    content: getContent(id),
-    isMaxSize: false,
-    size: {
-      width: 800,
-      height: 600,
+export const appsAtom = atom<AppData[]>({
+  key: "appsAtom",
+  default: [
+    {
+      id: "blog",
+      name: "Blog.minjong",
+      iconUrl: `/icons/app/blog.png`,
+      active: false,
+      content: <Blog />,
+      isMaxSize: false,
+      size: {
+        width: 800,
+        height: 600,
+      },
+      position: {
+        x: 50,
+        y: 50,
+      },
+      focus: false,
     },
-    position: {
-      x: 200,
-      y: 50,
+    {
+      id: "photo-booth",
+      name: "Photo Booth",
+      iconUrl: `/icons/app/photo-booth.png`,
+      active: false,
+      content: <PhotoBooth />,
+      isMaxSize: false,
+      size: {
+        width: 800,
+        height: 600,
+      },
+      position: {
+        x: 200,
+        y: 400,
+      },
+      focus: false,
     },
-  }),
+  ],
+});
+
+export const appState = selectorFamily({
+  key: "app",
+  get:
+    (appId: AppData["id"]) =>
+    ({ get }) =>
+      get(appsAtom).find((app) => app.id === appId) as AppData,
+  set:
+    (appId: AppData["id"]) =>
+    ({ set }, newValue) => {
+      set(appsAtom, (prevApps) => {
+        const apps = [...prevApps];
+        const index = apps.findIndex((app) => app.id === appId);
+        apps[index] = newValue as AppData;
+        return apps;
+      });
+    },
 });

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -13,4 +13,5 @@ export interface AppData {
     x: number;
     y: number;
   };
+  focus: boolean;
 }

--- a/src/utils/constants/app.ts
+++ b/src/utils/constants/app.ts
@@ -1,3 +1,3 @@
 import { AppData } from "@/types/app";
 
-export const appIds: AppData["id"][] = ["blog", "photo-booth"];
+export const DEFAULT_APP_IDS: AppData["id"][] = ["blog", "photo-booth"];


### PR DESCRIPTION
#8 

* 윈도우 컴포넌트에 focus 이벤트를 구현했어요.
  * 앱을 클릭하거나, 앱을 새로 띄울때 해당 앱이 제일 높은 z-index 값을 갖도록 구현했어요.
* app 상태 목록을 atomFamily 대신 atom을 사용하도록 변경했어요.
  * 특정 앱의 `focus: true`인 경우 다른 앱은 `focus:false`가 되어야 하는데 효율적인 구현 방법을 찾지 못해서 조금 무식한 방법으로 구현했는데 추후 리팩터링이 필요할 것 같아요.